### PR TITLE
feat: 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
@@ -33,6 +33,12 @@ public class AuthController {
         return ResponseEntity.ok(new BaseResponse<>(tokenResponse));
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logoutUser(@RequestHeader("Authorization") String accessToken) {
+        authService.logoutUser(accessToken);
+        return ResponseEntity.ok(new BaseResponse<>(BaseResponseStatus.SUCCESS));
+    }
+
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponse<RefreshTokenResponse>> refreshAccessToken(
             @RequestHeader("Authorization") String refreshToken) {

--- a/src/main/java/com/canvi/hama/domain/auth/service/AuthService.java
+++ b/src/main/java/com/canvi/hama/domain/auth/service/AuthService.java
@@ -73,6 +73,20 @@ public class AuthService {
     }
 
     @Transactional
+    public void logoutUser(String accessToken) {
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+
+        String username = tokenProvider.getUsernameFromJWT(accessToken);
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
+
+        user.clearRefreshToken();
+        userRepository.save(user);
+    }
+
+    @Transactional
     public RefreshTokenResponse generateNewAccessTokenFromRefreshToken(String refreshToken) {
         if (refreshToken != null && refreshToken.startsWith("Bearer ")) {
             refreshToken = refreshToken.substring(7);

--- a/src/main/java/com/canvi/hama/domain/user/domain/User.java
+++ b/src/main/java/com/canvi/hama/domain/user/domain/User.java
@@ -64,4 +64,8 @@ public class User extends BaseEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void clearRefreshToken() {
+        this.refreshToken = null;
+    }
 }


### PR DESCRIPTION
## 관련 이슈
close #9 

## 설명
- [POST] /api/auth/logout
- 로그아웃 요청시 해당 유저의 refreshToken 필드 null로 초기화