### PR TITLE
feat issue-#15: auth swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'		// swagger
+
 	compileOnly 'org.projectlombok:lombok'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/canvi/hama/common/config/SecurityConfig.java
+++ b/src/main/java/com/canvi/hama/common/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
+                        .requestMatchers("/swagger-ui/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptions -> exceptions
@@ -59,16 +61,6 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
-    }
-
-
-    // NON_AUTHENTICATED에 담긴 패턴은 ignore
-    @Bean
-    public WebSecurityCustomizer securityCustomizer() {
-        final String[] NON_AUTHENTICATED = {
-                "/**"
-        };
-        return web -> web.ignoring().requestMatchers(NON_AUTHENTICATED);
     }
 
 

--- a/src/main/java/com/canvi/hama/common/config/SwaggerConfig.java
+++ b/src/main/java/com/canvi/hama/common/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.canvi.hama.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("hama API")
+                .description("hama API")
+                .version("1.0");
+    }
+}

--- a/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.canvi.hama.domain.auth.dto.TokenResponse;
 import com.canvi.hama.domain.auth.service.AuthService;
 import com.canvi.hama.domain.auth.swagger.RefreshAccessTokenApi;
 import com.canvi.hama.domain.auth.swagger.UserAuthenticateApi;
+import com.canvi.hama.domain.auth.swagger.UserLogoutApi;
 import com.canvi.hama.domain.auth.swagger.UserRegisterApi;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class AuthController {
         return ResponseEntity.ok(new BaseResponse<>(tokenResponse));
     }
 
+    @UserLogoutApi
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logoutUser(@RequestHeader("Authorization") String accessToken) {
         authService.logoutUser(accessToken);

--- a/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
@@ -7,6 +7,10 @@ import com.canvi.hama.domain.auth.dto.RefreshTokenResponse;
 import com.canvi.hama.domain.auth.dto.SignupRequest;
 import com.canvi.hama.domain.auth.dto.TokenResponse;
 import com.canvi.hama.domain.auth.service.AuthService;
+import com.canvi.hama.domain.auth.swagger.RefreshAccessTokenApi;
+import com.canvi.hama.domain.auth.swagger.UserAuthenticateApi;
+import com.canvi.hama.domain.auth.swagger.UserRegisterApi;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,24 +19,29 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
 
+    @UserRegisterApi
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<Void>> registerUser(@RequestBody SignupRequest signUpRequest) {
         authService.registerUser(signUpRequest);
         return ResponseEntity.ok(new BaseResponse<>(BaseResponseStatus.SUCCESS));
     }
 
+
+    @UserAuthenticateApi
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<TokenResponse>> authenticateUser(@RequestBody LoginRequest loginRequest) {
         TokenResponse tokenResponse = authService.authenticateUser(loginRequest);
         return ResponseEntity.ok(new BaseResponse<>(tokenResponse));
     }
 
+    @RefreshAccessTokenApi
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponse<RefreshTokenResponse>> refreshAccessToken(
             @RequestHeader("Authorization") String refreshToken) {

--- a/src/main/java/com/canvi/hama/domain/auth/service/AuthService.java
+++ b/src/main/java/com/canvi/hama/domain/auth/service/AuthService.java
@@ -74,9 +74,11 @@ public class AuthService {
 
     @Transactional
     public void logoutUser(String accessToken) {
-        if (accessToken != null && accessToken.startsWith("Bearer ")) {
-            accessToken = accessToken.substring(7);
+        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+            throw new BaseException(BaseResponseStatus.INVALID_TOKEN);
         }
+
+        accessToken = accessToken.substring(7);
 
         String username = tokenProvider.getUsernameFromJWT(accessToken);
         User user = userRepository.findByUsername(username)

--- a/src/main/java/com/canvi/hama/domain/auth/swagger/RefreshAccessTokenApi.java
+++ b/src/main/java/com/canvi/hama/domain/auth/swagger/RefreshAccessTokenApi.java
@@ -1,0 +1,21 @@
+package com.canvi.hama.domain.auth.swagger;
+
+import com.canvi.hama.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = BaseResponse.class)))
+})
+public @interface RefreshAccessTokenApi {
+}

--- a/src/main/java/com/canvi/hama/domain/auth/swagger/UserAuthenticateApi.java
+++ b/src/main/java/com/canvi/hama/domain/auth/swagger/UserAuthenticateApi.java
@@ -1,0 +1,22 @@
+package com.canvi.hama.domain.auth.swagger;
+
+import com.canvi.hama.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Operation(summary = "로그인")
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = BaseResponse.class)))
+})
+public @interface UserAuthenticateApi {
+}

--- a/src/main/java/com/canvi/hama/domain/auth/swagger/UserLogoutApi.java
+++ b/src/main/java/com/canvi/hama/domain/auth/swagger/UserLogoutApi.java
@@ -1,0 +1,26 @@
+package com.canvi.hama.domain.auth.swagger;
+
+import com.canvi.hama.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.http.MediaType;
+
+@Operation(summary = "로그아웃")
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+                description = "로그아웃 성공",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = BaseResponse.class))),
+        @ApiResponse(responseCode = "401",
+                description = "인증 실패",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = BaseResponse.class)))
+})
+public @interface UserLogoutApi {
+}

--- a/src/main/java/com/canvi/hama/domain/auth/swagger/UserRegisterApi.java
+++ b/src/main/java/com/canvi/hama/domain/auth/swagger/UserRegisterApi.java
@@ -1,0 +1,23 @@
+package com.canvi.hama.domain.auth.swagger;
+
+import com.canvi.hama.common.response.BaseResponse;
+import com.canvi.hama.domain.auth.dto.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Operation(summary = "회원가입")
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = BaseResponse.class)))
+})
+public @interface UserRegisterApi {
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
> #15 

## 📝작업 내용
- SecurityConfig.java의 filterChain 메서드 내부에서 url 허용 경로를 나타내고 있어서 WebSecurityCustomizer 메서드 삭제했습니다
- swagger config로 title, description, version 추가
- swagger 경로: [http://localhost:8080/swagger-ui/index.html](url)
![image](https://github.com/user-attachments/assets/21e30157-53b1-43bf-9fac-e45e5a2bad38)

- response는 아래 코드와 같이 추가할 수 있습니다
```
@Operation(summary = "회원가입")
@Retention(RetentionPolicy.RUNTIME)
@ApiResponses(value = {
        @ApiResponse(responseCode = "200",
                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                        schema = @Schema(implementation = BaseResponse.class))),
        @ApiResponse(
                
        )
})
public @interface UserRegisterApi {
}
```