### PR TITLE
feat issue-#21: 캘린더 일기 조회 기능 구현

### DIFF
--- a/src/main/java/com/canvi/hama/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/canvi/hama/common/exception/GlobalExceptionHandler.java
@@ -2,12 +2,15 @@ package com.canvi.hama.common.exception;
 
 import com.canvi.hama.common.response.BaseResponse;
 import com.canvi.hama.common.response.BaseResponseStatus;
+import com.canvi.hama.domain.diary.exception.DiaryException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
@@ -20,5 +23,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<?>> handleGenericException(Exception ex) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(DiaryException.class)
+    public ResponseEntity<BaseResponse<?>> handleDiaryException(DiaryException ex) {
+        return ResponseEntity.status(ex.getStatus().getCode())
+                .body(new BaseResponse<>(ex.getStatus().isSuccess(), ex.getStatus().getCode(), ex.getStatus().getMessage()));
     }
 }

--- a/src/main/java/com/canvi/hama/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/canvi/hama/domain/diary/controller/DiaryController.java
@@ -1,5 +1,8 @@
 package com.canvi.hama.domain.diary.controller;
 
+import com.canvi.hama.common.exception.BaseException;
+import com.canvi.hama.common.response.BaseResponse;
+import com.canvi.hama.domain.diary.dto.DiarySummaryResponse;
 import com.canvi.hama.domain.diary.entity.Comment;
 import com.canvi.hama.domain.diary.entity.Diary;
 import com.canvi.hama.domain.diary.entity.Image;
@@ -14,6 +17,7 @@ import com.canvi.hama.domain.diary.response.DiaryResponseStatus;
 import com.canvi.hama.domain.diary.service.DiaryService;
 import com.canvi.hama.domain.diary.swagger.comment.GetCommentApi;
 import com.canvi.hama.domain.diary.swagger.comment.SaveCommentApi;
+import com.canvi.hama.domain.diary.swagger.diary.DiarySummeryGetApi;
 import com.canvi.hama.domain.diary.swagger.diary.GetDiaryApi;
 import com.canvi.hama.domain.diary.swagger.diary.SaveDiaryApi;
 import com.canvi.hama.domain.diary.swagger.image.GetImageApi;
@@ -29,6 +33,7 @@ import org.springframework.web.bind.annotation.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "Diary")
@@ -111,4 +116,13 @@ public class DiaryController {
         }
     }
 
+    @DiarySummeryGetApi
+    @GetMapping("/calendar/{userId}/{date}")
+    public BaseResponse<DiarySummaryResponse> getDiarySummary(@PathVariable Long userId, @PathVariable LocalDate date) {
+        try {
+            return new BaseResponse<>(diaryService.getDiaryByDate(userId, date));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/com/canvi/hama/domain/diary/dto/DiarySummaryResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/DiarySummaryResponse.java
@@ -1,18 +1,23 @@
 package com.canvi.hama.domain.diary.dto;
 
 import com.canvi.hama.domain.diary.entity.Diary;
+import com.canvi.hama.domain.diary.entity.Image;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
 public class DiarySummaryResponse {
     private String title;
     private String content;
+    private Image image;
 
     public DiarySummaryResponse(Diary diary) {
         this.title = diary.getTitle();
         this.content = diary.getContent();
+        this.image = diary.getImage();
     }
 
 }

--- a/src/main/java/com/canvi/hama/domain/diary/dto/DiarySummaryResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/DiarySummaryResponse.java
@@ -1,0 +1,18 @@
+package com.canvi.hama.domain.diary.dto;
+
+import com.canvi.hama.domain.diary.entity.Diary;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DiarySummaryResponse {
+    private String title;
+    private String content;
+
+    public DiarySummaryResponse(Diary diary) {
+        this.title = diary.getTitle();
+        this.content = diary.getContent();
+    }
+
+}

--- a/src/main/java/com/canvi/hama/domain/diary/entity/Diary.java
+++ b/src/main/java/com/canvi/hama/domain/diary/entity/Diary.java
@@ -33,4 +33,7 @@ public class Diary extends BaseEntity {
 
     @Column(name = "diary_date", nullable = false)
     private LocalDate diaryDate;
+
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    private Image image;
 }

--- a/src/main/java/com/canvi/hama/domain/diary/entity/Image.java
+++ b/src/main/java/com/canvi/hama/domain/diary/entity/Image.java
@@ -1,6 +1,7 @@
 package com.canvi.hama.domain.diary.entity;
 
 import com.canvi.hama.common.entity.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,7 +17,8 @@ public class Image extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonBackReference
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", referencedColumnName = "id", nullable = false)
     private Diary diary;
 

--- a/src/main/java/com/canvi/hama/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/canvi/hama/domain/diary/repository/DiaryRepository.java
@@ -4,11 +4,14 @@ import com.canvi.hama.domain.diary.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findByUserId(Long userId);
 
+    Optional<Diary> findByUserIdAndDiaryDate(Long userId, LocalDate date);
 }

--- a/src/main/java/com/canvi/hama/domain/diary/response/DiaryResponseStatus.java
+++ b/src/main/java/com/canvi/hama/domain/diary/response/DiaryResponseStatus.java
@@ -12,10 +12,13 @@ public enum DiaryResponseStatus {
     /** client error - 4xx */
     BAD_REQUEST(false, HttpStatus.BAD_REQUEST.value(), "요청 값이 옳지 않습니다."),
     NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "검색 결과가 존재하지 않습니다."),
+    DIARY_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 날짜에 일기가 존재하지 않습니다."),
+    DIARY_ALREADY_EXISTS(false, HttpStatus.CONFLICT.value(), "해당 날짜에 일기가 이미 존재합니다."),
 
-    INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "일기 관려 처리 중 에러가 발생했습니다."),
+    UNPROCESSABLE_ENTITY(false, HttpStatus.UNPROCESSABLE_ENTITY.value(), "API 응답 형식이 잘못되었습니다."),
 
-    UNPROCESSABLE_ENTITY(false, HttpStatus.UNPROCESSABLE_ENTITY.value(), "API 응답 형식이 잘못되었습니다.");
+    /** server error - 5xx */
+    INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "일기 관려 처리 중 에러가 발생했습니다.");
 
     private final boolean isSuccess;
     private final int code;

--- a/src/main/java/com/canvi/hama/domain/diary/swagger/diary/DiarySummeryGetApi.java
+++ b/src/main/java/com/canvi/hama/domain/diary/swagger/diary/DiarySummeryGetApi.java
@@ -1,0 +1,20 @@
+package com.canvi.hama.domain.diary.swagger.diary;
+
+import com.canvi.hama.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = BaseResponse.class)))
+})
+public @interface DiarySummeryGetApi {
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
#21 

## 📝작업 내용
- GlobalExceptionHandler에 DiaryException 등록했습니다
![스크린샷 2024-07-27 182156](https://github.com/user-attachments/assets/bcabe88d-3084-4ee9-a389-262b2868a13b)


- /diary/user/{userId} api에서 사용자가 존재하지 않을 때 공백 리스트를 반환해서 사용자가 존재하지 않으면 예외처리하는 부분 추가했습니다
- saveDiary 메서드에서 이미 일기가 작성된 날짜에는 일기 생성하지 못하게 처리했습니다!
- [GET] diary/calendar/{userId}/{date}: 날짜로 일기 조회할 수 있는 기능 추가



## 💬향후 개선사항
getDiariesByUserId 메서드에서 아래와 같이 diary 엔티티 자체를 반환하고 있는데 필요한 부분만 객체로 만들어서 보내는 건 어떨까요?
```
[
  {
    "createdAt": "2024-07-27T15:27:53.131798",
    "updatedAt": "2024-07-27T15:27:53.131798",
    "id": 1,
    "user": {
      "createdAt": "2024-07-27T15:27:21.275708",
      "updatedAt": "2024-07-27T15:27:21.276579",
      "id": 1,
      "username": "string1",
      "email": "string@gmail.com",
      "password": "$2a$10$6E1jCFddYRii/m5GfsLqtePcWnR4XkDzBzSa6gyObIM4vwdcVqRWu",
      "credits": 5,
      "refreshToken": null
    },
    "title": "string1",
    "content": "string1",
    "diaryDate": "2024-07-27"
  }
]
```