### PR TITLE
fix issue-#37: diary 관련 연관 관계 수정 및 테스트 코드 에러 수정

### DIFF
--- a/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/canvi/hama/domain/auth/controller/AuthController.java
@@ -65,13 +65,6 @@ public class AuthController {
         return ResponseEntity.ok(new BaseResponse<>(refreshTokenResponse));
     }
 
-    @GetMapping("/find-username")
-    public ResponseEntity<BaseResponse<String>> findUsernameByEmail(
-            @Valid @RequestParam @NotBlank(message = "이메일이 비었습니다.") @Email(message = "이메일 형식이 유효하지 않습니다.") String email) {
-        String username = authService.findUsernameByEmail(email);
-        return ResponseEntity.ok(new BaseResponse<>(username));
-    }
-
     @PostMapping("/reset-password")
     public ResponseEntity<BaseResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
         authService.resetPassword(request);

--- a/src/main/java/com/canvi/hama/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/canvi/hama/domain/auth/dto/request/LoginRequest.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
-        @NotBlank(message = "username을 입력하세요.")
-        String username,
+        @NotBlank(message = "이메일을 입력하세요.")
+        String email,
 
         @NotBlank(message = "password를 입력하세요.")
         @Size(min = 8, message = "password는 최소 8자 이상이어야 합니다.")

--- a/src/main/java/com/canvi/hama/domain/auth/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/canvi/hama/domain/auth/dto/request/ResetPasswordRequest.java
@@ -4,9 +4,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record ResetPasswordRequest(
-        @NotBlank(message = "username을 입력하세요.")
-        String username,
-
         @NotBlank(message = "email을 입력하세요.")
         @Email(message = "email 형식이 유효하지 않습니다.")
         String email

--- a/src/main/java/com/canvi/hama/domain/auth/service/AuthService.java
+++ b/src/main/java/com/canvi/hama/domain/auth/service/AuthService.java
@@ -100,14 +100,8 @@ public class AuthService {
         return new RefreshTokenResponse(newAccessToken);
     }
 
-    public String findUsernameByEmail(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
-        return user.getUsername();
-    }
-
     public void resetPassword(ResetPasswordRequest request) {
-        User user = userRepository.findByUsernameAndEmail(request.username(), request.email())
+        User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
 
         String newPassword = generateRandomPassword();

--- a/src/main/java/com/canvi/hama/domain/diary/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/response/CommentGetResponse.java
@@ -1,0 +1,9 @@
+package com.canvi.hama.domain.diary.dto.response;
+
+import com.canvi.hama.domain.diary.entity.Comment;
+
+public record CommentGetResponse(Long id, String comment) {
+    public CommentGetResponse(Comment comment) {
+        this(comment.getId(), comment.getComment());
+    }
+}

--- a/src/main/java/com/canvi/hama/domain/diary/dto/response/DiaryGetListResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/response/DiaryGetListResponse.java
@@ -1,0 +1,9 @@
+package com.canvi.hama.domain.diary.dto.response;
+
+import java.util.List;
+
+public record DiaryGetListResponse(List<DiaryGetResponse> diaryGetResponseList) {
+    public DiaryGetListResponse(List<DiaryGetResponse> diaryGetResponseList) {
+        this.diaryGetResponseList = diaryGetResponseList;
+    }
+}

--- a/src/main/java/com/canvi/hama/domain/diary/dto/response/DiaryGetResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/response/DiaryGetResponse.java
@@ -1,0 +1,23 @@
+package com.canvi.hama.domain.diary.dto.response;
+
+import com.canvi.hama.domain.diary.entity.Diary;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record DiaryGetResponse(Long id, String title, String content, CommentGetResponse comment, ImageGetResponse image, LocalDate date) {
+
+    public DiaryGetResponse(Diary diary) {
+        this(diary.getId(), diary.getTitle(), diary.getContent(),
+                diary.getComment() != null ? new CommentGetResponse(diary.getComment()) : null,
+                diary.getImage() != null ? new ImageGetResponse(diary.getImage()) : null,
+                diary.getDiaryDate());
+    }
+
+    public static List<DiaryGetResponse> fromDiaryList(List<Diary> diaries) {
+        return diaries.stream()
+                .map(DiaryGetResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/canvi/hama/domain/diary/dto/response/ImageGetResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/response/ImageGetResponse.java
@@ -1,0 +1,9 @@
+package com.canvi.hama.domain.diary.dto.response;
+
+import com.canvi.hama.domain.diary.entity.Image;
+
+public record ImageGetResponse(Long id, String url) {
+    public ImageGetResponse(Image image) {
+        this(image.getId(), image.getUrl());
+    }
+}

--- a/src/main/java/com/canvi/hama/domain/diary/entity/Comment.java
+++ b/src/main/java/com/canvi/hama/domain/diary/entity/Comment.java
@@ -1,15 +1,7 @@
 package com.canvi.hama.domain.diary.entity;
 
 import com.canvi.hama.common.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,8 +18,7 @@ public class Comment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diary_id")
+    @OneToOne(mappedBy = "comment")
     @NotNull
     private Diary diary;
 

--- a/src/main/java/com/canvi/hama/domain/diary/entity/Diary.java
+++ b/src/main/java/com/canvi/hama/domain/diary/entity/Diary.java
@@ -2,15 +2,7 @@ package com.canvi.hama.domain.diary.entity;
 
 import com.canvi.hama.common.entity.BaseEntity;
 import com.canvi.hama.domain.user.entity.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -46,6 +38,14 @@ public class Diary extends BaseEntity {
     @NotNull
     private LocalDate diaryDate;
 
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Diary(User user, String title, String content, LocalDate diaryDate) {
         this.user = user;
@@ -62,4 +62,8 @@ public class Diary extends BaseEntity {
                 .diaryDate(diaryDate)
                 .build();
     }
+
+    public void setImage(Image image) { this.image = image; }
+
+    public void setComment(Comment comment) { this.comment = comment; }
 }

--- a/src/main/java/com/canvi/hama/domain/diary/entity/Image.java
+++ b/src/main/java/com/canvi/hama/domain/diary/entity/Image.java
@@ -15,8 +15,7 @@ public class Image extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diary_id")
+    @OneToOne(mappedBy = "image")
     private Diary diary;
 
     @Column(name = "url")

--- a/src/main/java/com/canvi/hama/domain/diary/enums/DiaryResponseStatus.java
+++ b/src/main/java/com/canvi/hama/domain/diary/enums/DiaryResponseStatus.java
@@ -12,13 +12,18 @@ public enum DiaryResponseStatus {
     /** client error - 4xx */
     BAD_REQUEST(false, HttpStatus.BAD_REQUEST.value(), "요청 값이 옳지 않습니다."),
     NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "검색 결과가 존재하지 않습니다."),
-    DIARY_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 날짜에 일기가 존재하지 않습니다."),
+    DIARY_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "일기가 존재하지 않습니다."),
     DIARY_ALREADY_EXISTS(false, HttpStatus.CONFLICT.value(), "해당 날짜에 일기가 이미 존재합니다."),
+    INVALID_DATE_FORMAT(false, HttpStatus.BAD_REQUEST.value(), "잘못된 날짜 형식입니다."),
 
     UNPROCESSABLE_ENTITY(false, HttpStatus.UNPROCESSABLE_ENTITY.value(), "API 응답 형식이 잘못되었습니다."),
 
     /** server error - 5xx */
-    INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "일기 관려 처리 중 에러가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "일기 관려 처리 중 에러가 발생했습니다."),
+    DATABASE_INSERT_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "데이터베이스 저장에 실패하였습니다."),
+
+
+    ;
 
     private final boolean isSuccess;
     private final int code;

--- a/src/main/java/com/canvi/hama/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/canvi/hama/domain/diary/repository/DiaryRepository.java
@@ -2,7 +2,11 @@ package com.canvi.hama.domain.diary.repository;
 
 import com.canvi.hama.domain.diary.entity.Diary;
 import com.canvi.hama.domain.user.entity.User;
+
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,9 +15,4 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findAllByUser(User user);
 
-<<<<<<< HEAD
-    Optional<Diary> findByUserIdAndDiaryDate(Long userId, LocalDate date);
-    boolean existsByUserIdAndDiaryDate(Long userId, LocalDate date);
-=======
->>>>>>> develop
 }

--- a/src/main/java/com/canvi/hama/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/canvi/hama/domain/diary/repository/DiaryRepository.java
@@ -15,4 +15,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findAllByUser(User user);
 
+    Optional<Diary> findByUserIdAndDiaryDate(Long id, LocalDate date);
+
 }

--- a/src/main/java/com/canvi/hama/domain/diary/swagger/comment/GetCommentApi.java
+++ b/src/main/java/com/canvi/hama/domain/diary/swagger/comment/GetCommentApi.java
@@ -1,7 +1,6 @@
 package com.canvi.hama.domain.diary.swagger.comment;
 
 import com.canvi.hama.common.response.BaseResponse;
-import com.canvi.hama.domain.diary.entity.Comment;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,7 +16,7 @@ import java.lang.annotation.RetentionPolicy;
 @ApiResponses(value = {
         @ApiResponse(responseCode = "201",
                 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = @Schema(implementation = Comment.class)))
+                        schema = @Schema(implementation = BaseResponse.class)))
 })
 public @interface GetCommentApi {
 }

--- a/src/main/java/com/canvi/hama/domain/diary/swagger/diary/GetDiaryApi.java
+++ b/src/main/java/com/canvi/hama/domain/diary/swagger/diary/GetDiaryApi.java
@@ -1,5 +1,6 @@
 package com.canvi.hama.domain.diary.swagger.diary;
 
+import com.canvi.hama.common.response.BaseResponse;
 import com.canvi.hama.domain.diary.entity.Diary;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -7,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -16,7 +18,7 @@ import java.lang.annotation.RetentionPolicy;
 @ApiResponses(value = {
         @ApiResponse(responseCode = "201",
                 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = @Schema(implementation = Diary.class)))
+                        schema = @Schema(implementation = BaseResponse.class)))
 })
 public @interface GetDiaryApi {
 }

--- a/src/main/java/com/canvi/hama/domain/user/exception/UserException.java
+++ b/src/main/java/com/canvi/hama/domain/user/exception/UserException.java
@@ -1,6 +1,5 @@
 package com.canvi.hama.domain.user.exception;
 
-import com.canvi.hama.domain.diary.response.DiaryResponseStatus;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/canvi/hama/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/canvi/hama/domain/user/repository/UserRepository.java
@@ -11,8 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByUsernameAndEmail(String username, String email);
-
     boolean existsByEmail(String email);
 
     boolean existsByUsername(String username);

--- a/src/test/java/com/canvi/hama/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/canvi/hama/diary/controller/DiaryControllerTest.java
@@ -6,11 +6,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.canvi.hama.domain.auth.dto.request.LoginRequest;
 import com.canvi.hama.domain.auth.dto.request.SignupRequest;
 import com.canvi.hama.domain.auth.service.EmailAuthService;
-import com.canvi.hama.domain.diary.entity.Diary;
-import com.canvi.hama.domain.diary.exception.DiaryException;
+import com.canvi.hama.domain.diary.dto.response.DiaryGetResponse;
 import com.canvi.hama.domain.diary.dto.request.DiaryRequest;
-import com.canvi.hama.domain.diary.enums.DiaryResponseStatus;
 import com.canvi.hama.domain.user.entity.User;
+import com.canvi.hama.domain.user.exception.UserException;
+import com.canvi.hama.domain.user.exception.UserResponseStatus;
 import com.canvi.hama.domain.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -51,9 +51,9 @@ public class DiaryControllerTest {
         Mockito.when(emailAuthService.isEmailVerified(Mockito.anyString())).thenReturn(true);
 
         // 테스트용 계정 생성
-        String testUsername = "testuser";
+        String testEmail = "test@example.com";
         String testPassword = "password123";
-        SignupRequest signupRequest = new SignupRequest(testUsername, "test@example.com", testPassword);
+        SignupRequest signupRequest = new SignupRequest("testuser", testEmail, testPassword);
 
         given()
                 .contentType(ContentType.JSON)
@@ -64,7 +64,7 @@ public class DiaryControllerTest {
                 .statusCode(HttpStatus.OK.value());
 
         // 로그인 후 액세스 토큰을 받아옵니다
-        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
         Response loginResponse = given()
                 .contentType(ContentType.JSON)
                 .body(loginRequest)
@@ -76,10 +76,10 @@ public class DiaryControllerTest {
         accessToken = loginResponse.jsonPath().getString("result.accessToken");
 
         // userId 받아오기
-        String userName = loginResponse.jsonPath().getString("result.username");
+        String email = loginResponse.jsonPath().getString("result.username");
         User user = userRepository
-                .findByUsername(userName)
-                .orElseThrow(() -> new DiaryException(DiaryResponseStatus.NOT_FOUND));
+                .findByEmail(email)
+                .orElseThrow(() -> new UserException(UserResponseStatus.NOT_FOUND));
 
         userId = user.getId();
     }
@@ -124,9 +124,9 @@ public class DiaryControllerTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract().response();
 
-        List<Diary> diaries = response.jsonPath().getList(".", Diary.class);
+        List<DiaryGetResponse> diaries = response.jsonPath().getList("result.diaryGetResponseList", DiaryGetResponse.class);
         assertThat(diaries).isNotEmpty();
-        assertThat(diaries.get(0).getTitle()).isEqualTo("Test Title");
-        assertThat(diaries.get(0).getContent()).isEqualTo("Test Content");
+        assertThat(diaries.get(0).title()).isEqualTo("Test Title");
+        assertThat(diaries.get(0).content()).isEqualTo("Test Content");
     }
 }

--- a/src/test/java/com/canvi/hama/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/canvi/hama/domain/auth/controller/AuthControllerTest.java
@@ -85,7 +85,7 @@ public class AuthControllerTest {
 
     @Test
     public void whenValidLogin_thenReturnsToken() {
-        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
 
         Response response = given()
                 .contentType(ContentType.JSON)
@@ -96,7 +96,7 @@ public class AuthControllerTest {
                 .extract().response();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getString("result.username")).isEqualTo(testUsername);
+        assertThat(response.jsonPath().getString("result.username")).isEqualTo(testEmail);
         assertThat(response.jsonPath().getString("result.accessToken")).isNotBlank();
         assertThat(response.jsonPath().getString("result.refreshToken")).isNotBlank();
     }
@@ -104,7 +104,7 @@ public class AuthControllerTest {
     @Test
     public void whenValidRefreshToken_thenReturnsNewAccessToken() {
         // 로그인 후 리프레시 토큰 받기
-        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
         Response loginResponse = given()
                 .contentType(ContentType.JSON)
                 .body(loginRequest)
@@ -141,7 +141,7 @@ public class AuthControllerTest {
     @Test
     public void whenLogout_thenReturnsSuccess() {
         // 먼저 로그인
-        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
         Response loginResponse = given()
                 .contentType(ContentType.JSON)
                 .body(loginRequest)
@@ -170,37 +170,10 @@ public class AuthControllerTest {
         assertThat(refreshResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
-    @Test
-    public void whenFindUsernameByValidEmail_thenReturnsUsername() {
-        Response response = given()
-                .contentType(ContentType.URLENC)
-                .param("email", testEmail)
-                .when()
-                .get("/api/auth/find-username")
-                .then()
-                .extract().response();
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getString("result")).isEqualTo(testUsername);
-    }
-
-    @Test
-    public void whenFindUsernameByInvalidEmail_thenReturnsError() {
-        String invalidEmail = "nonexistent@example.com";
-        Response response = given()
-                .contentType(ContentType.URLENC)
-                .param("email", invalidEmail)
-                .when()
-                .get("/api/auth/find-username")
-                .then()
-                .extract().response();
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
 
     @Test
     public void whenResetPasswordWithValidData_thenReturnsSuccess() {
-        ResetPasswordRequest request = new ResetPasswordRequest(testUsername, testEmail);
+        ResetPasswordRequest request = new ResetPasswordRequest(testEmail);
 
         Response response = given()
                 .contentType(ContentType.JSON)
@@ -215,7 +188,7 @@ public class AuthControllerTest {
 
     @Test
     public void whenResetPasswordWithInvalidData_thenReturnsError() {
-        ResetPasswordRequest request = new ResetPasswordRequest("invaliduser", "invalid@example.com");
+        ResetPasswordRequest request = new ResetPasswordRequest("invalid@example.com");
 
         Response response = given()
                 .contentType(ContentType.JSON)
@@ -231,7 +204,7 @@ public class AuthControllerTest {
     @Test
     public void whenResetPasswordAndLogin_thenLoginSucceeds() {
         // 먼저 비밀번호 재설정
-        ResetPasswordRequest resetRequest = new ResetPasswordRequest(testUsername, testEmail);
+        ResetPasswordRequest resetRequest = new ResetPasswordRequest(testEmail);
         given()
                 .contentType(ContentType.JSON)
                 .body(resetRequest)
@@ -240,7 +213,7 @@ public class AuthControllerTest {
 
         // 로그인 시도 (새 비밀번호는 이메일로 전송되므로 여기서는 확인할 수 없음)
         // 대신 로그인 실패 테스트를 수행
-        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
 
         Response loginResponse = given()
                 .contentType(ContentType.JSON)
@@ -256,7 +229,7 @@ public class AuthControllerTest {
     @Test
     public void whenWithdrawWithValidUser_thenReturnsSuccess() {
         // 먼저 로그인
-        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
         Response loginResponse = given()
                 .contentType(ContentType.JSON)
                 .body(loginRequest)


### PR DESCRIPTION
## #️⃣ 관련 이슈
close #24 #37 

## 📝작업 내용
- diary-image, diary-comment 각각 일대일 관계로 수정했습니다.
- 서로 참조하고 있는 관계에서 entity를 그대로 반환하면 순환 참조 에러가 발생해서 `DiaryGetResponse`, `CommentGetResponse`, `ImageGetResponse` 추가해서 dto를 반환하게 바꿨습니다.
- [GET] /diaries 에서 List< DiaryGetResponse >로 리턴하는 것보다 DiaryGetListResponse 객체로 보내는 게 프론트에서 처리하기 편하므로 ListResponse로 반환하게 수정했습니다.

- "/find-username" api 삭제
- 비밀번호 초기화 요청에서 username 삭제
- 캘린더 화면에서 날짜를 선택했을 때 해당 날짜의 일기만 반환해야 하므로, 날짜로 일기 조회하는 api 추가했습니다
- 토큰 식별 방식을 email로 바꿨으므로 이에 맞게 test 코드 수정
- 테스트 코드에서 저장된 일기 응답 받아오는 부분을         `List<DiaryGetResponse> diaries = diaryResponse.jsonPath().getList("result.diaryGetResponseList", DiaryGetResponse.class); ` 이렇게 수정했습니다.   
<br>   

> PathVariable에서 URL 경로 이름과 메서드 파라미터 이름이 같으면 따로 변수 이름을 명시하지 않아도 되지만 저는 자동으로 매핑이 안돼서 변수 이름을 지정했습니다..