### PR TITLE
refactor: 다이어리 생성 response 수정, ai api 리팩토링

### DIFF
--- a/src/main/java/com/canvi/hama/domain/ai/dto/request/DalleRequest.java
+++ b/src/main/java/com/canvi/hama/domain/ai/dto/request/DalleRequest.java
@@ -3,22 +3,15 @@ package com.canvi.hama.domain.ai.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record DalleRequest(
-        @NotBlank
-        Long diaryId,
-
-        @NotBlank
         String gender,
 
-        @NotBlank
         String age,
 
-        @NotBlank
         String hairStyle,
 
-        @NotBlank
         String clothes,
 
-        @NotBlank
+        @NotBlank(message = "prompt를 입력하세요.")
         String prompt
 ) {
 }

--- a/src/main/java/com/canvi/hama/domain/ai/service/GptService.java
+++ b/src/main/java/com/canvi/hama/domain/ai/service/GptService.java
@@ -86,14 +86,26 @@ public class GptService {
     }
 
     private String createDallePrompt(DalleRequest request, String translatedPrompt) {
-        return "I will tell you the contents of my diary, so please analyze them and draw them with emotional and cute pictures. "
-                +
-                "Choose one of the contents of the diary and draw it. My information is as follows. " +
-                "My Gender is " + request.gender() + " " +
-                "My Age is " + request.age() + " " +
-                "My Hair style is " + request.hairStyle() + " " +
-                "My clothes is " + request.clothes() + " " +
-                "The contents of my diary are as follows.. " + translatedPrompt;
+        StringBuilder messageBuilder = new StringBuilder();
+
+        messageBuilder.append(
+                        "I will tell you the contents of my diary, so please analyze them and draw them with emotional and cute pictures. ")
+                .append("Choose one of the contents of the diary and draw it. My information is as follows. ");
+
+        appendAttribute(messageBuilder, "Gender", request.gender());
+        appendAttribute(messageBuilder, "Age", request.age());
+        appendAttribute(messageBuilder, "HairStyle", request.hairStyle());
+        appendAttribute(messageBuilder, "Clothes", request.clothes());
+
+        messageBuilder.append("The contents of my diary are as follows.. ").append(translatedPrompt);
+
+        return messageBuilder.toString();
+    }
+
+    private void appendAttribute(StringBuilder builder, String attributeName, String attributeValue) {
+        if (attributeValue != null && !attributeValue.isBlank()) {
+            builder.append("My ").append(attributeName).append(" is ").append(attributeValue).append(" ");
+        }
     }
 
     private <T> T callOpenAiApi(String url, Map<String, Object> requestBody) {

--- a/src/main/java/com/canvi/hama/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/canvi/hama/domain/diary/controller/DiaryController.java
@@ -7,6 +7,7 @@ import com.canvi.hama.domain.diary.dto.request.ImageSaveRequest;
 import com.canvi.hama.domain.diary.dto.response.CommentGetResponse;
 import com.canvi.hama.domain.diary.dto.response.DiaryGetListResponse;
 import com.canvi.hama.domain.diary.dto.response.DiaryGetResponse;
+import com.canvi.hama.domain.diary.dto.response.SaveDiaryResponse;
 import com.canvi.hama.domain.diary.enums.DiaryResponseStatus;
 import com.canvi.hama.domain.diary.service.DiaryService;
 import com.canvi.hama.domain.diary.swagger.comment.GetCommentApi;
@@ -46,10 +47,9 @@ public class DiaryController {
 
     @SaveDiaryApi
     @PostMapping
-    public ResponseEntity<DiaryResponseStatus> saveDiary(@AuthenticationPrincipal UserDetails userDetails,
+    public BaseResponse<SaveDiaryResponse> saveDiary(@AuthenticationPrincipal UserDetails userDetails,
                                                          @RequestBody @Valid DiaryRequest diaryRequest) {
-        diaryService.saveDiary(userDetails, diaryRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).body(DiaryResponseStatus.CREATED);
+        return new BaseResponse<>(diaryService.saveDiary(userDetails, diaryRequest));
     }
 
     @GetDiaryApi

--- a/src/main/java/com/canvi/hama/domain/diary/dto/response/SaveDiaryResponse.java
+++ b/src/main/java/com/canvi/hama/domain/diary/dto/response/SaveDiaryResponse.java
@@ -1,0 +1,6 @@
+package com.canvi.hama.domain.diary.dto.response;
+
+public record SaveDiaryResponse(
+        Long id
+) {
+}

--- a/src/main/java/com/canvi/hama/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/canvi/hama/domain/diary/service/DiaryService.java
@@ -5,6 +5,7 @@ import com.canvi.hama.domain.diary.dto.request.DiaryRequest;
 import com.canvi.hama.domain.diary.dto.response.CommentGetResponse;
 import com.canvi.hama.domain.diary.dto.response.DiaryGetListResponse;
 import com.canvi.hama.domain.diary.dto.response.DiaryGetResponse;
+import com.canvi.hama.domain.diary.dto.response.SaveDiaryResponse;
 import com.canvi.hama.domain.diary.entity.Comment;
 import com.canvi.hama.domain.diary.entity.Diary;
 import com.canvi.hama.domain.diary.entity.Image;
@@ -14,7 +15,7 @@ import com.canvi.hama.domain.diary.repository.CommentRepository;
 import com.canvi.hama.domain.diary.repository.DiaryRepository;
 import com.canvi.hama.domain.diary.repository.ImageRepository;
 import com.canvi.hama.domain.user.entity.User;
-
+import com.canvi.hama.domain.user.service.UserService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,11 +28,8 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
-
-import com.canvi.hama.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cglib.core.Local;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -52,10 +50,11 @@ public class DiaryService {
     private final UserService userService;
 
     @Transactional
-    public void saveDiary(UserDetails userDetails, DiaryRequest diaryRequest) {
+    public SaveDiaryResponse saveDiary(UserDetails userDetails, DiaryRequest diaryRequest) {
         User user = userService.getUserFromUserDetails(userDetails);
         Diary diary = Diary.create(user, diaryRequest.title(), diaryRequest.content(), diaryRequest.diaryDate());
         diaryRepository.save(diary);
+        return new SaveDiaryResponse(diary.getId());
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Issue
close #48 

## Details
- POST /diaries 의 response에 생성된 diaryId를 담아 반환하도록 했습니다.
- POST /api/dalle 의 request에 불필요하게 선언되어 있던 diaryId를 제거했습니다.
- 또한 prompt를 제외한 gender, age, hairstyle, clothes 등은 선택적으로 받을 수 있도록 했습니다.